### PR TITLE
Create common lambda package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# IDE
+/.idea
+
 # General
 /build
 

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,8 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml
-# Datasource local storage ignored files
-/dataSources/
-/dataSources.local.xml
-# Editor-based HTTP Client requests
-/httpRequests/

--- a/.idea/bjss.poker.iml
+++ b/.idea/bjss.poker.iml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="WEB_MODULE" version="4">
-  <component name="NewModuleRootManager">
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="Encoding">
-    <file url="PROJECT" charset="UTF-8" />
-  </component>
-</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="SwUserDefinedSpecifications">
-    <option name="specTypeByUrl">
-      <map />
-    </option>
-  </component>
-</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/bjss.poker.iml" filepath="$PROJECT_DIR$/.idea/bjss.poker.iml" />
-    </modules>
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/README.md
+++ b/README.md
@@ -21,3 +21,6 @@ each lambda directory. These are then mapped to websocket API actions via the `l
 
 All contained within `terraform/`. Terraform is also used to handle deployments, reading code from the `lambdas/` and
 `frontend/public/` directories and uploading them to AWS Lambda and AWS S3 respectively.
+
+Both `zip` and `jq` must be available on the environment that terraform is run in, as well as support for running bash
+files.

--- a/lambda/changename/package-lock.json
+++ b/lambda/changename/package-lock.json
@@ -84,6 +84,9 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
+    "vote-poker-common": {
+      "version": "file:../common"
+    },
     "xml2js": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",

--- a/lambda/changename/package.json
+++ b/lambda/changename/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "aws-sdk": "^2.903.0"
+    "aws-sdk": "^2.903.0",
+    "vote-poker-common": "file:../common"
   }
 }

--- a/lambda/changeroomsettings/package-lock.json
+++ b/lambda/changeroomsettings/package-lock.json
@@ -84,6 +84,9 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
+    "vote-poker-common": {
+      "version": "file:../common"
+    },
     "xml2js": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",

--- a/lambda/changeroomsettings/package.json
+++ b/lambda/changeroomsettings/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "aws-sdk": "^2.903.0"
+    "aws-sdk": "^2.903.0",
+    "vote-poker-common": "file:../common"
   }
 }

--- a/lambda/common/package-lock.json
+++ b/lambda/common/package-lock.json
@@ -1,0 +1,5 @@
+{
+    "name": "vote-poker-common",
+    "version": "0.0.1",
+    "lockfileVersion": 1
+}

--- a/lambda/common/package.json
+++ b/lambda/common/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "vote-poker-common",
+    "version": "0.0.1"
+}

--- a/lambda/connect/package-lock.json
+++ b/lambda/connect/package-lock.json
@@ -84,6 +84,9 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
+    "vote-poker-common": {
+      "version": "file:../common"
+    },
     "xml2js": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",

--- a/lambda/connect/package.json
+++ b/lambda/connect/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "aws-sdk": "^2.903.0"
+    "aws-sdk": "^2.903.0",
+    "vote-poker-common": "file:../common"
   }
 }

--- a/lambda/createroom/package-lock.json
+++ b/lambda/createroom/package-lock.json
@@ -91,6 +91,9 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
+    "vote-poker-common": {
+      "version": "file:../common"
+    },
     "xml2js": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",

--- a/lambda/createroom/package.json
+++ b/lambda/createroom/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "aws-sdk": "^2.903.0",
-    "uuid": "^8.3.2"
+    "uuid": "^8.3.2",
+    "vote-poker-common": "file:../common"
   }
 }

--- a/lambda/disconnect/package-lock.json
+++ b/lambda/disconnect/package-lock.json
@@ -84,6 +84,9 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
+    "vote-poker-common": {
+      "version": "file:../common"
+    },
     "xml2js": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",

--- a/lambda/disconnect/package.json
+++ b/lambda/disconnect/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "aws-sdk": "^2.903.0"
+    "aws-sdk": "^2.903.0",
+    "vote-poker-common": "file:../common"
   }
 }

--- a/lambda/joinroom/package-lock.json
+++ b/lambda/joinroom/package-lock.json
@@ -84,6 +84,9 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
+    "vote-poker-common": {
+      "version": "file:../common"
+    },
     "xml2js": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",

--- a/lambda/joinroom/package.json
+++ b/lambda/joinroom/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "aws-sdk": "^2.903.0"
+    "aws-sdk": "^2.903.0",
+    "vote-poker-common": "file:../common"
   }
 }

--- a/lambda/ping/package-lock.json
+++ b/lambda/ping/package-lock.json
@@ -1,5 +1,11 @@
 {
   "name": "vote-poker-lambda-ping",
   "version": "1.0.0",
-  "lockfileVersion": 1
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "vote-poker-common": {
+      "version": "file:../common"
+    }
+  }
 }

--- a/lambda/ping/package.json
+++ b/lambda/ping/package.json
@@ -2,5 +2,7 @@
   "name": "vote-poker-lambda-ping",
   "version": "1.0.0",
   "private": true,
-  "dependencies": {}
+  "dependencies": {
+    "vote-poker-common": "file:../common"
+  }
 }

--- a/lambda/placevote/package-lock.json
+++ b/lambda/placevote/package-lock.json
@@ -84,6 +84,9 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
+    "vote-poker-common": {
+      "version": "file:../common"
+    },
     "xml2js": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",

--- a/lambda/placevote/package.json
+++ b/lambda/placevote/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "aws-sdk": "^2.903.0"
+    "aws-sdk": "^2.903.0",
+    "vote-poker-common": "file:../common"
   }
 }

--- a/lambda/resetvotes/package-lock.json
+++ b/lambda/resetvotes/package-lock.json
@@ -84,6 +84,9 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
+    "vote-poker-common": {
+      "version": "file:../common"
+    },
     "xml2js": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",

--- a/lambda/resetvotes/package.json
+++ b/lambda/resetvotes/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "aws-sdk": "^2.903.0"
+    "aws-sdk": "^2.903.0",
+    "vote-poker-common": "file:../common"
   }
 }

--- a/lambda/revealvotes/package-lock.json
+++ b/lambda/revealvotes/package-lock.json
@@ -84,6 +84,9 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
+    "vote-poker-common": {
+      "version": "file:../common"
+    },
     "xml2js": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",

--- a/lambda/revealvotes/package.json
+++ b/lambda/revealvotes/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "aws-sdk": "^2.903.0"
+    "aws-sdk": "^2.903.0",
+    "vote-poker-common": "file:../common"
   }
 }

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,41 +1,41 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/hashicorp/archive" {
-  version     = "2.2.0"
-  constraints = ">= 2.2.0, < 3.0.0"
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.34.0"
+  constraints = ">= 4.11.0, < 5.0.0"
   hashes = [
-    "h1:Rxkd7mWSvHMLppeKeW6+7BxWGP0h4xZdfb5sd4pGQq8=",
-    "zh:06bd875932288f235c16e2237142b493c2c2b6aba0e82e8c85068332a8d2a29e",
-    "zh:0c681b481372afcaefddacc7ccdf1d3bb3a0c0d4678a526bc8b02d0c331479bc",
-    "zh:100fc5b3fc01ea463533d7bbfb01cb7113947a969a4ec12e27f5b2be49884d6c",
-    "zh:55c0d7ddddbd0a46d57c51fcfa9b91f14eed081a45101dbfc7fd9d2278aa1403",
-    "zh:73a5dd68379119167934c48afa1101b09abad2deb436cd5c446733e705869d6b",
-    "zh:841fc4ac6dc3479981330974d44ad2341deada8a5ff9e3b1b4510702dfbdbed9",
-    "zh:91be62c9b41edb137f7f835491183628d484e9d6efa82fcb75cfa538c92791c5",
-    "zh:acd5f442bd88d67eb948b18dc2ed421c6c3faee62d3a12200e442bfff0aa7d8b",
-    "zh:ad5720da5524641ad718a565694821be5f61f68f1c3c5d2cfa24426b8e774bef",
-    "zh:e63f12ea938520b3f83634fc29da28d92eed5cfbc5cc8ca08281a6a9c36cca65",
-    "zh:f6542918faa115df46474a36aabb4c3899650bea036b5f8a5e296be6f8f25767",
+    "h1:YtszJA9OaR7qIrVw7DUnxwulsSOPiYv+uJ9MWsQBzAg=",
+    "zh:2bdc9b908008c1e874d8ba7e2cfabd856cafb63c52fef51a1fdeef2f5584bffd",
+    "zh:43c5364e3161be3856e56494cbb8b21d513fc05875f1b40e66e583602154dd0a",
+    "zh:44e763adae92489f223f65866c1f8b5342e7e85b95daa8d1f483a2afb47f7db3",
+    "zh:62bfabb3a1a31814cb3fadc356539d8253b95abacfffd90984affb54c9a53a86",
+    "zh:6495ce67897d2d5648d466c09e8588e837c2878322988738a95c06926044b05d",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:b1546b2ac61d7cc27a8eba160ae1b6ac581d2c4af824a400d6511e4998da398a",
+    "zh:c8c362c5527f0533bde581e41cdb2bdf42aea557762f326dbfa122fdf001fb10",
+    "zh:c8cc28fb41f73ca09f590bace2204ea325f6116be0bbce6abfebd393d028f12c",
+    "zh:db0601c9bd12ca028d60ac87e85320285ebc64857715f7908dd6a283e5f44d45",
+    "zh:e64d2193236d05348ba2e8b99650d9274e5af80be39b3ee28bbe442b0684d8a3",
+    "zh:ff6228f3751e1f0ee7dc086d09e32d39ca6556f0b5267f36aae67881d29ace94",
   ]
 }
 
-provider "registry.terraform.io/hashicorp/aws" {
-  version     = "4.11.0"
-  constraints = ">= 4.11.0, < 5.0.0"
+provider "registry.terraform.io/hashicorp/external" {
+  version = "2.2.2"
   hashes = [
-    "h1:pNfFRxEDBXlvNHfoz7zRzExSktzSUY6DZizTGnG9vQ4=",
-    "zh:3e4634f4babcef402160ffb97f9f37e3e781313ceb7b7858fe4b7fc0e2e33e99",
-    "zh:3ff647aa88e71419480e3f51a4b40e3b0e2d66482bea97c0b4e75f37aa5ad1f1",
-    "zh:4680d16fbb85663034dc3677b402e9e78ab1d4040dd80603052817a96ec08911",
-    "zh:5190d03f43f7ad56dae0a7f0441a0f5b2590f42f6e07a724fe11dd50c42a12e4",
-    "zh:622426fcdbb927e7c198fe4b890a01a5aa312e462cd82ae1e302186eeac1d071",
-    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:b0b766a835c79f8dd58b93d25df8f37749f33cca2297ac088d402d718baddd9c",
-    "zh:b293cf26a02992b2167ed3f63711dc01221c4a5e2984b6c7c0c04a6155ab0526",
-    "zh:ca8e1f5c58fc838edb5fe7528aec3f2fcbaeabf808add0f401aee5073b61f17f",
-    "zh:e0d2ad2767c0134841d52394d180f8f3315c238949c8d11be39a214630e8d50e",
-    "zh:ece0d11c35a8537b662287e00af4d27a27eb9558353b133674af90ec11c818d3",
-    "zh:f7e1cd07ae883d3be01942dc2b0d516b9736a74e6037287ab19f616725c8f7e8",
+    "h1:5907Z/VOLV770KacxmmM1jG4H1l6ruXAvKPQAB0sMNc=",
+    "zh:0b84ab0af2e28606e9c0c1289343949339221c3ab126616b831ddb5aaef5f5ca",
+    "zh:10cf5c9b9524ca2e4302bf02368dc6aac29fb50aeaa6f7758cce9aa36ae87a28",
+    "zh:56a016ee871c8501acb3f2ee3b51592ad7c3871a1757b098838349b17762ba6b",
+    "zh:719d6ef39c50e4cffc67aa67d74d195adaf42afcf62beab132dafdb500347d39",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7fbfc4d37435ac2f717b0316f872f558f608596b389b895fcb549f118462d327",
+    "zh:8ac71408204db606ce63fe8f9aeaf1ddc7751d57d586ec421e62d440c402e955",
+    "zh:a4cacdb06f114454b6ed0033add28006afa3f65a0ea7a43befe45fc82e6809fb",
+    "zh:bb5ce3132b52ae32b6cc005bc9f7627b95259b9ffe556de4dad60d47d47f21f0",
+    "zh:bb60d2976f125ffd232a7ccb4b3f81e7109578b23c9c6179f13a11d125dca82a",
+    "zh:f9540ecd2e056d6e71b9ea5f5a5cf8f63dd5c25394b9db831083a9d4ea99b372",
+    "zh:ffd998b55b8a64d4335a090b6956b4bf8855b290f7554dd38db3302de9c41809",
   ]
 }

--- a/terraform/_vote_poker.providers.tf
+++ b/terraform/_vote_poker.providers.tf
@@ -20,7 +20,7 @@ terraform {
     }
 
     archive = {
-      source  = "hashicorp/archive"
+      source  = "hashicorp/external"
       version = ">= 2.2, < 3"
     }
   }

--- a/terraform/api_route.vote_poker.tf
+++ b/terraform/api_route.vote_poker.tf
@@ -1,4 +1,4 @@
-module "api_route2" {
+module "api_route" {
   source = "./modules/api_route"
 
   for_each = local.lambda_route_mapping

--- a/terraform/aws_apigatewayv2_deployment.vote_poker.tf
+++ b/terraform/aws_apigatewayv2_deployment.vote_poker.tf
@@ -2,7 +2,7 @@ resource "aws_apigatewayv2_deployment" "vote_poker" {
   api_id = aws_apigatewayv2_api.vote_poker.id
 
   triggers = {
-    redeployment = sha1(join(",", [for api_route in module.api_route2 : api_route.api_route_key]))
+    redeployment = sha1(join(",", [for api_route in module.api_route : api_route.api_route_key]))
   }
 
   lifecycle {

--- a/terraform/modules/api_route/archive.sh
+++ b/terraform/modules/api_route/archive.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+ARGS=$(cat -)
+INPUT_PATH=$(echo $ARGS | jq -r ".input_path")
+OUTPUT_PATH=$(echo $ARGS | jq -r ".output_path")
+
+rm -f $OUTPUT_PATH
+
+cd $INPUT_PATH
+zip -rqX $OUTPUT_PATH ./*
+
+OUTPUT_HASH=$(cat $OUTPUT_PATH | openssl sha -binary -sha256 | base64)
+
+jq -ncM \
+  '{ "output_path": $output_path, "output_hash": $output_hash }' \
+  --arg output_path "$OUTPUT_PATH" \
+  --arg output_hash "$OUTPUT_HASH"

--- a/terraform/modules/api_route/aws_lambda_function.api_route.tf
+++ b/terraform/modules/api_route/aws_lambda_function.api_route.tf
@@ -10,8 +10,8 @@ resource "aws_lambda_function" "api_route" {
 
   publish = true
 
-  filename         = data.archive_file.api_route.output_path
-  source_code_hash = data.archive_file.api_route.output_base64sha256
+  filename         = data.external.archive_api_route.result.output_path
+  source_code_hash = data.external.archive_api_route.result.output_hash
 
   environment {
     variables = {

--- a/terraform/modules/api_route/data.archive_file.api_route.tf
+++ b/terraform/modules/api_route/data.archive_file.api_route.tf
@@ -1,6 +1,0 @@
-data "archive_file" "api_route" {
-  type = "zip"
-
-  source_dir  = "${path.root}/../lambda/${var.lambda_function_name}/"
-  output_path = "${path.root}/../build/lambdas/${var.lambda_function_name}.zip"
-}

--- a/terraform/modules/api_route/data.external.archive_api_route.tf
+++ b/terraform/modules/api_route/data.external.archive_api_route.tf
@@ -1,0 +1,8 @@
+data "external" "archive_api_route" {
+  program = ["sh", "${path.module}/archive.sh"]
+
+  query = {
+    input_path = "${abspath(path.root)}/../lambda/${var.lambda_function_name}/"
+    output_path = "${abspath(path.root)}/../build/lambdas/${var.lambda_function_name}.zip"
+  }
+}


### PR DESCRIPTION
Work towards issue #2 

Terraform's archive_file provider doesn't support zipping up directories that are symbolic links. Switch out the zip functionality to an external script that is called with the external provider that does support this functionality until archive_file is fixed (https://github.com/hashicorp/terraform-provider-archive/issues/6)

Create a common package (empty at the moment) and include that as a local package in all the other lambdas, ready for use.

Also remove the IDE files (keep changing my mind on whether to commit these or not) and rename the api_route2 module definition to api_route - needed when changing domain name in the past but now the old names have gone I can tidy up.

This adds a dependency on zip being available wherever terraform is run.